### PR TITLE
Add more links in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 The first thing you want to do with this repo is quite likely **fork it**.  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with [branches](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches), [issues](https://www.google.ro/search?client=safari&source=hp&ei=glPFXeiGGcz6qwGevrjwDA&q=github+issues&oq=github+issues&gs_l=psy-ab.3..0l10.1338.3301..3412...0.0..1.266.1258.12j0j1......0....1..gws-wiz.2UM9hntiag0&ved=0ahUKEwjoz4Ksw9rlAhVM_SoKHR4fDs4Q4dUDCAk&uact=5), [milestones](https://help.github.com/en/github/managing-your-work-on-github/about-milestones), labels, the wiki, and more.
+Once you’re on your fork, you can experiment however you like with it, play with [branches](www.google.ro), [issues](https://www.google.ro/search?client=safari&source=hp&ei=glPFXeiGGcz6qwGevrjwDA&q=github+issues&oq=github+issues&gs_l=psy-ab.3..0l10.1338.3301..3412...0.0..1.266.1258.12j0j1......0....1..gws-wiz.2UM9hntiag0&ved=0ahUKEwjoz4Ksw9rlAhVM_SoKHR4fDs4Q4dUDCAk&uact=5), [milestones](https://help.github.com/en/github/managing-your-work-on-github/about-milestones), labels, the wiki, and more.
 
 ## What’s in there?
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 The first thing you want to do with this repo is quite likely **fork it**.  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
+Once you’re on your fork, you can experiment however you like with it, play with [branches](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches), [issues](https://www.google.ro/search?client=safari&source=hp&ei=glPFXeiGGcz6qwGevrjwDA&q=github+issues&oq=github+issues&gs_l=psy-ab.3..0l10.1338.3301..3412...0.0..1.266.1258.12j0j1......0....1..gws-wiz.2UM9hntiag0&ved=0ahUKEwjoz4Ksw9rlAhVM_SoKHR4fDs4Q4dUDCAk&uact=5), [milestones](https://help.github.com/en/github/managing-your-work-on-github/about-milestones), labels, the wiki, and more.
 
 ## What’s in there?
 


### PR DESCRIPTION
We provide more links in the Github Oreilly Readme file for newbies on the following: branches, issues and milestones